### PR TITLE
Fix Swift spec

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # RBQSafeRealmObject & SafeRealmObject
 
+## 1.0.2
+
+- Removed objc files from SafeRealmObject (swift) spec
+
 ## 1.0.1
 
 - Fixed RealmUtilities import in RBQSafeRealmObject

--- a/SafeRealmObject.podspec
+++ b/SafeRealmObject.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name         = "SafeRealmObject"
-  s.version      = "1.0.0"
+  s.version      = "1.0.2"
   s.summary      = "Thread-safe representation of a Realm Swift Object"
   s.description  = <<-DESC
 SafeRealmObject offers a thread-safe class that represents a Realm Swift Object subclass with a primary key and can be used across threads.

--- a/SafeRealmObject.podspec
+++ b/SafeRealmObject.podspec
@@ -12,8 +12,7 @@ SafeRealmObject offers a thread-safe class that represents a Realm Swift Object 
   s.social_media_url   = "http://twitter.com/Roobiq"
   s.platform     = :ios, "8.0"
   s.source       = { :git => "https://github.com/Roobiq/RBQSafeRealmObject.git", :tag => "v#{s.version}"}
-  s.source_files  = "*.{h,m,swift}"
-  s.private_header_files = '*.h'
+  s.source_files  = "*.swift"
   s.requires_arc = true
   s.dependency "RBQSafeRealmObject"
   s.dependency "RealmSwift", ">=0.99.1"


### PR DESCRIPTION
Now that the SafeRealmObject pods depends on the RBQSafeRealmObject pod, the objc files are redundant in the former.

Resolves an import issue identified in Roobiq/RBQFetchedResultsController#103